### PR TITLE
Basic support for positional arguments & assorted changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,19 @@ jobs:
         run: opam exec -- dune build @all @lint
 
       - name: Run tests
-        run: opam exec -- dune runtest
+        run: |
+             mkdir $BISECT_DIR
+             opam exec -- dune runtest --instrument-with bisect_ppx
+        env:
+          BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data
+          BISECT_FILE: ${{ runner.temp }}/_bisect_ppx_data/data
+
+      - name: Send coverage report to Coveralls
+        run: opam exec -- bisect-ppx-report send-to Coveralls --coverage-path $BISECT_DIR
+        env:
+          BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}
 
       - name: Check for uncommitted changes
         run: git diff --exit-code

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,18 @@
 
 ### Added
 
+- Basic support for positional arguments.
+- Enabled instrumentation.
+- Adopted OCaml Code of Conduct.
+- Added a FAQ page.
+- Added test libraries.
+
 ### Changed
 
+- Update tutorial to include positional arguments.
+
 ### Fixed
+
+- Translation to `core.command` requires `(unit -> _) Command.t`
 
 ### Removed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # commandlang
 
 [![CI Status](https://github.com/mbarbin/commandlang/workflows/ci/badge.svg)](https://github.com/mbarbin/commandlang/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/mbarbin/commandlang/badge.svg?branch=main)](https://coveralls.io/github/mbarbin/commandlang?branch=main)
+[![Deploy Doc Status](https://github.com/mbarbin/commandlang/workflows/deploy-doc/badge.svg)](https://github.com/mbarbin/commandlang/actions/workflows/deploy-doc.yml)
 
 Declarative Command-line Parsing for OCaml.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There is also a third library under development:
 
 3. [climate](https://github.com/gridbugs/climate), aiming to support autocompletion scripts and other conventions.
 
-The following table reflects our understanding and preferences (ranked 1-3) as of the early days of `commandlang` (your mileage may vary):
+The following table reflects our understanding and preferences (ranked 1-3, most preferred first) as of the early days of `commandlang` (your mileage may vary):
 
 |     Library    |  Runtime (eval)        |  Ergonomic (mli)  |  CLI conventions  | Man pages  |  Auto-complete  |
 |----------------|:----------------------:|:-----------------:|:-----------------:|:----------:|:---------------:|
@@ -71,7 +71,7 @@ We initiated the library as part of another project where we are migrating some 
 
 3. **Translation Libraries**:
    - Convert `commandlang` parsers at runtime into `cmdliner`, `core.command`, or `climate` parsers
-   - Packaged as three separate helper libraries to keep dependencies isolated.
+   - Packaged as separate helper libraries to keep dependencies isolated.
 
 ## Experimental Status
 

--- a/commandlang-test.opam
+++ b/commandlang-test.opam
@@ -11,11 +11,13 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
   "base" {>= "v0.17" & < "v0.18"}
+  "bisect_ppx" {dev & >= "2.8.3"}
   "climate" {= "0.0.1~preview-0.1"}
   "cmdliner" {= "1.3.0"}
   "commandlang" {= version}
   "core" {>= "v0.17" & < "v0.18"}
   "core_unix" {>= "v0.17" & < "v0.18"}
+  "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
   "mdx" {>= "2.4"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}

--- a/doc/docs/explanation/faq.md
+++ b/doc/docs/explanation/faq.md
@@ -1,0 +1,15 @@
+# Frequently Asked Questions
+
+## Why Questions
+
+#### Why aren't there more helpers exposed?
+
+We are currently in an exploratory phase and need to easily update our internal representations. Adding too many helpers now would complicate this process. Therefore, we aim to balance providing enough functionality for early trials while keeping the core minimal. We plan to revisit this later with user feedback.
+
+#### Why isn't Commandlang's Arg parser an arrow?
+
+We are uncertain if all targeted models support branching. When writing a CLI for an OCaml program, encoding variants in the CLI can create a clear mapping between the user interface and the internal implementation. However, this approach might complicate the CLI. Commandlang aims to operate at the intersection of its targeted backends, which could be a significant constraint if you need functionality only offered in a specific backend. This is an area for future development. If you need a feature that is only available in another CLI library, commandlang might not be a good fit for your project.
+
+## Other Questions
+
+Feel free to ask any other questions about commandlang.

--- a/doc/docs/explanation/future_plans.md
+++ b/doc/docs/explanation/future_plans.md
@@ -2,17 +2,30 @@
 
 In this section, we outline some areas of uncertainty regarding the feasibility of our design in detail. These are the areas we plan to explore next.
 
-## Anonymous Arguments (Positional Arguments)
+## Positional Arguments
+
+*Also known as anonymous arguments in `core.command`.*
 
 One of the key areas we need to investigate further is the handling of anonymous arguments, also known as positional arguments in `cmdliner` and `climate`. Due to the differences in how these arguments are managed in `core.command`, translating them may not be as straightforward as it is for named arguments.
 
 However, we have a good intuition that by reducing some of the expressiveness of what we allow to construct, we can solve cases that are sufficient in practice. For example, enforcing that positional arguments be defined in left-to-right order in the specification might be a viable approach.
+
+### Tasks
+- [x] Investigate handling of anonymous arguments in `cmdliner` and `climate` (Completed: Aug 2024)
+- [x] Develop a strategy for translating positional arguments in `core.command` (Completed: Aug 2024)
+- [x] Implement left-to-right order enforcement for positional arguments when compiling to `core.command` (Completed: Aug 2024)
 
 ## Generation of Complex Man Pages
 
 Another area of focus is the generation of complex man pages. `cmdliner` has excellent support for these. Currently, we have added basic support for one-line summaries of help messages to get started. However, we believe we could reuse most of the design of `cmdliner` and add it as optional information to the specification language.
 
 The rendering to simple strings could be exported by a standalone `cmdliner` helper library to reduce dependencies. We could then reuse and integrate this in the translation to `core.command` and `climate`. This part is more prospective and may require some coordination with the developers of other libraries.
+
+### Tasks
+- [ ] Add support for one-line summaries of help messages
+- [ ] Design optional information for specification language based on `cmdliner`
+- [ ] Create a standalone `cmdliner` helper library for rendering to simple strings
+- [ ] Integrate `cmdliner` design into `core.command` and `climate`
 
 ## Auto-Completion
 
@@ -21,3 +34,8 @@ The third point is by far the most challenging but also a source of significant 
 We envision a potential hybrid translation mode where a `commandlang` command is translated into both `cmdliner` and `climate` — `cmdliner` for runtime execution and `climate` to generate completion scripts. This approach leaves the question of reentrant completion as future work.
 
 Given the ongoing developments in other libraries regarding auto-completion, we will carefully consider how `commandlang`'s unique architecture can accommodate and leverage these changes. This will require thoughtful planning and possibly significant adjustments as the landscape evolves.
+
+### Tasks
+- [ ] Research auto-completion support in `climate`
+- [ ] Develop a hybrid translation mode for `commandlang` commands
+- [ ] Implement auto-completion feature

--- a/doc/docs/tutorials/getting-started/README.md
+++ b/doc/docs/tutorials/getting-started/README.md
@@ -19,7 +19,7 @@ For example, if you are using a local opam switch, follow these steps:
 
 <!-- $MDX skip -->
 ```sh
-$ opam switch create . 5.2.0 --no-install
+$ cd /path/to/your/local/switch
 $ eval $(opam env)
 $ opam repo add mbarbin https://github.com/mbarbin/opam-repository.git
 ```

--- a/doc/docs/tutorials/getting-started/bin/dune
+++ b/doc/docs/tutorials/getting-started/bin/dune
@@ -1,4 +1,6 @@
 (executable
  (name main)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries commandlang_to_cmdliner cmdliner getting_started))
+ (libraries cmdliner commandlang_to_cmdliner getting_started)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/doc/docs/tutorials/getting-started/bin/main.ml
+++ b/doc/docs/tutorials/getting-started/bin/main.ml
@@ -1,10 +1,8 @@
 let () =
-  match
-    Cmdliner.Cmd.eval_value'
-      (Commandlang_to_cmdliner.Translate.command
-         Getting_started.cmd
-         ~name:"my-calculator")
-  with
-  | `Ok () -> ()
-  | `Exit code -> exit code
+  Cmdliner.Cmd.eval
+    (Commandlang_to_cmdliner.Translate.command
+       Getting_started.cmd
+       ~name:"my-calculator"
+       ~version:"%%VERSION%%")
+  |> Stdlib.exit
 ;;

--- a/doc/docs/tutorials/getting-started/lib/dune
+++ b/doc/docs/tutorials/getting-started/lib/dune
@@ -9,4 +9,6 @@
   +a
   -open
   Commandlang)
- (libraries commandlang))
+ (libraries commandlang)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/doc/docs/tutorials/getting-started/lib/getting_started.ml
+++ b/doc/docs/tutorials/getting-started/lib/getting_started.ml
@@ -22,7 +22,7 @@ end
 (* $MDX part-begin=void *)
 let cmd =
   Command.make
-    ~doc:"A simple calculator"
+    ~summary:"A simple calculator"
     (let open Command.Std in
      let+ () = Arg.return () in
      ())
@@ -34,15 +34,12 @@ let _ = cmd
 (* $MDX part-begin=final *)
 let cmd =
   Command.make
-    ~doc:"A simple calculator"
+    ~summary:"A simple calculator"
     (let open Command.Std in
      let+ op =
-       Arg.named_req
-         [ "op" ]
-         ~doc:"operation to perform"
-         (Param.enum (Operator.all |> List.map (fun op -> Operator.to_string op, op)))
-     and+ a = Arg.named_req [ "a" ] ~doc:"first operand" Param.float
-     and+ b = Arg.named_req [ "b" ] ~doc:"second operand" Param.float
+       Arg.named [ "op" ] (Param.enumerated (module Operator)) ~doc:"operation to perform"
+     and+ a = Arg.pos 0 ~docv:"a" Param.float ~doc:"first operand"
+     and+ b = Arg.pos 1 ~docv:"b" Param.float ~doc:"second operand"
      and+ verbose = Arg.flag [ "verbose" ] ~doc:"print debug information" in
      if verbose then Printf.printf "op: %s, a: %f, b: %f\n" (Operator.to_string op) a b;
      print_endline (Operator.eval op a b |> string_of_float))

--- a/doc/sidebars.ts
+++ b/doc/sidebars.ts
@@ -49,6 +49,7 @@ const sidebars: SidebarsConfig = {
       items: [
         { type: 'doc', id: 'explanation/README', label: 'Introduction' },
         { type: 'doc', id: 'explanation/future_plans', label: 'Future Plans' },
+        { type: 'doc', id: 'explanation/faq', label: 'Frequently Asked Questions' },
       ],
     },
   ],

--- a/doc/src/pages/index.md
+++ b/doc/src/pages/index.md
@@ -9,6 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/mbarbin/commandlang/actions/workflows/ci.yml"><img src="https://github.com/mbarbin/commandlang/workflows/ci/badge.svg" alt="CI Status"/></a>
+  <a href="https://coveralls.io/github/mbarbin/commandlang?branch=main"><img src="https://coveralls.io/repos/github/mbarbin/commandlang/badge.svg?branch=main" alt="Coverage Status"/></a>
   <a href="https://github.com/mbarbin/commandlang/actions/workflows/deploy-doc.yml"><img src="https://github.com/mbarbin/commandlang/workflows/deploy-doc/badge.svg" alt="Deploy Doc Status"/></a>
 </p>
 

--- a/dune-project
+++ b/dune-project
@@ -112,6 +112,10 @@
    (and
     (>= v0.17)
     (< v0.18)))
+  (bisect_ppx
+   (and
+    :dev
+    (>= 2.8.3)))
   (climate
    (= 0.0.1~preview-0.1))
   (cmdliner
@@ -123,6 +127,10 @@
     (>= v0.17)
     (< v0.18)))
   (core_unix
+   (and
+    (>= v0.17)
+    (< v0.18)))
+  (expect_test_helpers_core
    (and
     (>= v0.17)
     (< v0.18)))

--- a/lib/commandlang/src/dune
+++ b/lib/commandlang/src/dune
@@ -10,6 +10,8 @@
   -open
   Commandlang_ast)
  (libraries commandlang_ast)
+ (instrumentation
+  (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess no_preprocessing))

--- a/lib/commandlang/test/dune
+++ b/lib/commandlang/test/dune
@@ -1,0 +1,35 @@
+(library
+ (name commandlang_test)
+ (public_name commandlang-test.commandlang_test)
+ (inline_tests)
+ (flags
+  :standard
+  -w
+  +a-4-40-41-42-44-45-48-66
+  -warn-error
+  +a
+  -open
+  Base
+  -open
+  Expect_test_helpers_base
+  -open
+  Commandlang)
+ (libraries
+  base
+  commandlang
+  expect_test_helpers_core.expect_test_helpers_base)
+ (instrumentation
+  (backend bisect_ppx))
+ (lint
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+ (preprocess
+  (pps
+   -unused-code-warnings=force
+   ppx_compare
+   ppx_enumerate
+   ppx_expect
+   ppx_hash
+   ppx_here
+   ppx_let
+   ppx_sexp_conv
+   ppx_sexp_value)))

--- a/lib/commandlang/test/test__command.ml
+++ b/lib/commandlang/test/test__command.ml
@@ -1,0 +1,8 @@
+let%expect_test "Param.enum" =
+  let open Command.Std in
+  require_does_raise [%here] (fun () ->
+    let+ _ = Arg.named [ "a" ] (Param.assoc []) ~doc:"empty enum" in
+    ());
+  [%expect {| (Invalid_argument Command.Arg.enum) |}];
+  ()
+;;

--- a/lib/commandlang_ast/src/ast.ml
+++ b/lib/commandlang_ast/src/ast.ml
@@ -44,6 +44,13 @@ module Arg = struct
         ; doc : string
         }
         -> bool t
+    | Named :
+        { names : string Nonempty_list.t
+        ; doc : string
+        ; docv : string option
+        ; param : 'a Param.t
+        }
+        -> 'a t
     | Named_opt :
         { names : string Nonempty_list.t
         ; doc : string
@@ -59,25 +66,46 @@ module Arg = struct
         ; default : 'a
         }
         -> 'a t
-    | Named_req :
-        { names : string Nonempty_list.t
-        ; doc : string
+    | Pos :
+        { doc : string option
         ; docv : string option
+        ; index : int
         ; param : 'a Param.t
         }
         -> 'a t
+    | Pos_opt :
+        { doc : string option
+        ; docv : string option
+        ; index : int
+        ; param : 'a Param.t
+        }
+        -> 'a option t
+    | Pos_with_default :
+        { doc : string option
+        ; docv : string option
+        ; index : int
+        ; param : 'a Param.t
+        ; default : 'a
+        }
+        -> 'a t
+    | Pos_all :
+        { doc : string option
+        ; docv : string option
+        ; param : 'a Param.t
+        }
+        -> 'a list t
 end
 
 module Command = struct
   type 'a t =
     | Make :
         { arg : 'a Arg.t
-        ; doc : string
+        ; summary : string
         }
         -> 'a t
     | Group :
         { default : 'a Arg.t option
-        ; doc : string
+        ; summary : string
         ; subcommands : (string * 'a t) list
         }
         -> 'a t

--- a/lib/commandlang_ast/src/ast.mli
+++ b/lib/commandlang_ast/src/ast.mli
@@ -44,6 +44,13 @@ module Arg : sig
         ; doc : string
         }
         -> bool t
+    | Named :
+        { names : string Nonempty_list.t
+        ; doc : string
+        ; docv : string option
+        ; param : 'a Param.t
+        }
+        -> 'a t
     | Named_opt :
         { names : string Nonempty_list.t
         ; doc : string
@@ -59,25 +66,46 @@ module Arg : sig
         ; default : 'a
         }
         -> 'a t
-    | Named_req :
-        { names : string Nonempty_list.t
-        ; doc : string
+    | Pos :
+        { doc : string option
         ; docv : string option
+        ; index : int
         ; param : 'a Param.t
         }
         -> 'a t
+    | Pos_opt :
+        { doc : string option
+        ; docv : string option
+        ; index : int
+        ; param : 'a Param.t
+        }
+        -> 'a option t
+    | Pos_with_default :
+        { doc : string option
+        ; docv : string option
+        ; index : int
+        ; param : 'a Param.t
+        ; default : 'a
+        }
+        -> 'a t
+    | Pos_all :
+        { doc : string option
+        ; docv : string option
+        ; param : 'a Param.t
+        }
+        -> 'a list t
 end
 
 module Command : sig
   type 'a t =
     | Make :
         { arg : 'a Arg.t
-        ; doc : string
+        ; summary : string
         }
         -> 'a t
     | Group :
         { default : 'a Arg.t option
-        ; doc : string
+        ; summary : string
         ; subcommands : (string * 'a t) list
         }
         -> 'a t

--- a/lib/commandlang_ast/src/dune
+++ b/lib/commandlang_ast/src/dune
@@ -2,6 +2,8 @@
  (name commandlang_ast)
  (public_name commandlang.ast)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
+ (instrumentation
+  (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess no_preprocessing))

--- a/lib/commandlang_ast/test/dune
+++ b/lib/commandlang_ast/test/dune
@@ -1,0 +1,21 @@
+(library
+ (name commandlang_ast_test)
+ (public_name commandlang-test.commandlang_ast_test)
+ (inline_tests)
+ (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
+ (libraries commandlang_ast)
+ (instrumentation
+  (backend bisect_ppx))
+ (lint
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+ (preprocess
+  (pps
+   -unused-code-warnings=force
+   ppx_compare
+   ppx_enumerate
+   ppx_expect
+   ppx_hash
+   ppx_here
+   ppx_let
+   ppx_sexp_conv
+   ppx_sexp_value)))

--- a/lib/commandlang_to_base/src/dune
+++ b/lib/commandlang_to_base/src/dune
@@ -12,6 +12,8 @@
   -open
   Commandlang_ast)
  (libraries base commandlang commandlang.ast core.command)
+ (instrumentation
+  (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess

--- a/lib/commandlang_to_base/src/translate.mli
+++ b/lib/commandlang_to_base/src/translate.mli
@@ -14,4 +14,14 @@ module Config : sig
     -> t
 end
 
-val basic : ?config:Config.t -> unit Commandlang.Command.t -> Command.t
+val basic : ?config:Config.t -> (unit -> unit) Commandlang.Command.t -> Command.t
+
+val or_error
+  :  ?config:Config.t
+  -> (unit -> unit Or_error.t) Commandlang.Command.t
+  -> Command.t
+
+(** [unit] can be a convenient helper during a migration, however note that it
+    is probably not quite right, due to the body of the command being evaluated
+    as an argument. *)
+val unit : ?config:Config.t -> unit Commandlang.Command.t -> Command.t

--- a/lib/commandlang_to_base/test/dune
+++ b/lib/commandlang_to_base/test/dune
@@ -1,0 +1,21 @@
+(library
+ (name commandlang_to_base_test)
+ (public_name commandlang-test.commandlang_to_base_test)
+ (inline_tests)
+ (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
+ (libraries commandlang_to_base)
+ (instrumentation
+  (backend bisect_ppx))
+ (lint
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+ (preprocess
+  (pps
+   -unused-code-warnings=force
+   ppx_compare
+   ppx_enumerate
+   ppx_expect
+   ppx_hash
+   ppx_here
+   ppx_let
+   ppx_sexp_conv
+   ppx_sexp_value)))

--- a/lib/commandlang_to_climate/src/dune
+++ b/lib/commandlang_to_climate/src/dune
@@ -10,6 +10,8 @@
   -open
   Commandlang_ast)
  (libraries climate commandlang commandlang.ast)
+ (instrumentation
+  (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess no_preprocessing))

--- a/lib/commandlang_to_climate/test/dune
+++ b/lib/commandlang_to_climate/test/dune
@@ -1,0 +1,21 @@
+(library
+ (name commandlang_to_climate_test)
+ (public_name commandlang-test.commandlang_to_climate_test)
+ (inline_tests)
+ (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
+ (libraries commandlang_to_climate)
+ (instrumentation
+  (backend bisect_ppx))
+ (lint
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+ (preprocess
+  (pps
+   -unused-code-warnings=force
+   ppx_compare
+   ppx_enumerate
+   ppx_expect
+   ppx_hash
+   ppx_here
+   ppx_let
+   ppx_sexp_conv
+   ppx_sexp_value)))

--- a/lib/commandlang_to_cmdliner/src/dune
+++ b/lib/commandlang_to_cmdliner/src/dune
@@ -10,6 +10,8 @@
   -open
   Commandlang_ast)
  (libraries cmdliner commandlang commandlang.ast)
+ (instrumentation
+  (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess no_preprocessing))

--- a/lib/commandlang_to_cmdliner/src/translate.mli
+++ b/lib/commandlang_to_cmdliner/src/translate.mli
@@ -1,1 +1,5 @@
-val command : 'a Commandlang.Command.t -> name:string -> 'a Cmdliner.Cmd.t
+val command
+  :  ?version:string
+  -> 'a Commandlang.Command.t
+  -> name:string
+  -> 'a Cmdliner.Cmd.t

--- a/lib/commandlang_to_cmdliner/test/dune
+++ b/lib/commandlang_to_cmdliner/test/dune
@@ -1,0 +1,21 @@
+(library
+ (name commandlang_to_cmdliner_test)
+ (public_name commandlang-test.commandlang_to_cmdliner_test)
+ (inline_tests)
+ (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
+ (libraries commandlang_to_cmdliner)
+ (instrumentation
+  (backend bisect_ppx))
+ (lint
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+ (preprocess
+  (pps
+   -unused-code-warnings=force
+   ppx_compare
+   ppx_enumerate
+   ppx_expect
+   ppx_hash
+   ppx_here
+   ppx_let
+   ppx_sexp_conv
+   ppx_sexp_value)))

--- a/test/base/bin/dune
+++ b/test/base/bin/dune
@@ -2,4 +2,6 @@
  (name main_base)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
  (libraries commandlang_to_base core_unix.command_unix test_command)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess no_preprocessing))

--- a/test/base/bin/main_base.ml
+++ b/test/base/bin/main_base.ml
@@ -1,1 +1,1 @@
-let () = Command_unix.run (Commandlang_to_base.Translate.basic Test_command.cmd)
+let () = Command_unix.run (Commandlang_to_base.Translate.unit Test_command.cmd)

--- a/test/base/run.t
+++ b/test/base/run.t
@@ -10,6 +10,7 @@
     cmd2                       . Hello let%bind command
     cmd3                       . Hello cmd3
     cmd4                       . Hello let%bind command
+    cmd5                       . Hello positional
     version                    . print version information
     help                       . explain a given subcommand (perhaps recursively)
   
@@ -162,3 +163,19 @@
 
   $ ./main_base.exe cmd4 -n 3.14
   3.14
+
+  $ ./main_base.exe cmd5 --help
+  Hello positional
+  
+    main_base.exe cmd5 A B [C]
+  
+  === flags ===
+  
+    [-help], -?                . print this help text and exit
+  
+
+  $ ./main_base.exe cmd5 1.2 3.4
+  ((a 1.2) (b 3.4) (c 3.14))
+
+  $ ./main_base.exe cmd5 1.2 3.4 5.6
+  ((a 1.2) (b 3.4) (c 5.6))

--- a/test/climate/bin/dune
+++ b/test/climate/bin/dune
@@ -2,4 +2,6 @@
  (name main_climate)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
  (libraries climate commandlang_to_climate test_command)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess no_preprocessing))

--- a/test/climate/run.t
+++ b/test/climate/run.t
@@ -13,6 +13,7 @@
    cmd2  Hello let%bind command
    cmd3  Hello cmd3
    cmd4  Hello let%bind command
+   cmd5  Hello positional
 
   $ ./main_climate.exe cmd1 --help
   Usage: ./main_climate.exe cmd1 [OPTIONS]
@@ -127,3 +128,17 @@
 
   $ ./main_climate.exe cmd4 -n 3.14
   3.14
+
+  $ ./main_climate.exe cmd5 --help
+  Usage: ./main_climate.exe cmd5 [OPTIONS] <A> <B>
+  
+  Hello positional
+  
+  Options:
+   --help, -h   Print help
+
+  $ ./main_climate.exe cmd5 1.2 3.4
+  ((a 1.2) (b 3.4) (c 3.14))
+
+  $ ./main_climate.exe cmd5 1.2 3.4 5.6
+  ((a 1.2) (b 3.4) (c 5.6))

--- a/test/cmdliner/bin/dune
+++ b/test/cmdliner/bin/dune
@@ -2,4 +2,6 @@
  (name main_cmdliner)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
  (libraries cmdliner commandlang_to_cmdliner test_command)
+ (instrumentation
+  (backend bisect_ppx))
  (preprocess no_preprocessing))

--- a/test/cmdliner/bin/main_cmdliner.ml
+++ b/test/cmdliner/bin/main_cmdliner.ml
@@ -1,8 +1,8 @@
 let () =
-  match
-    Cmdliner.Cmd.eval_value'
-      (Commandlang_to_cmdliner.Translate.command Test_command.cmd ~name:Sys.argv.(0))
-  with
-  | `Ok () -> ()
-  | `Exit code -> exit code
+  Cmdliner.Cmd.eval
+    (Commandlang_to_cmdliner.Translate.command
+       Test_command.cmd
+       ~name:Sys.argv.(0)
+       ~version:"%%VERSION%%")
+  |> Stdlib.exit
 ;;

--- a/test/cmdliner/run.t
+++ b/test/cmdliner/run.t
@@ -19,11 +19,17 @@
          cmd4 [-n VAL] [OPTION]…
              Hello let%bind command
   
+         cmd5 [OPTION]… A B [C]
+             Hello positional
+  
   COMMON OPTIONS
          --help[=FMT] (default=auto)
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          ./main_cmdliner.exe exits with:
@@ -48,6 +54,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          ./main_cmdliner.exe cmd1 exits with:
@@ -82,6 +91,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          ./main_cmdliner.exe cmd2 exits with:
@@ -135,6 +147,9 @@
              Show this help in format FMT. The value FMT must be one of auto,
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
   
   EXIT STATUS
          ./main_cmdliner.exe cmd3 exits with:
@@ -209,6 +224,9 @@
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
+         --version
+             Show version information.
+  
   EXIT STATUS
          ./main_cmdliner.exe cmd4 exits with:
   
@@ -251,3 +269,40 @@
 
   $ ./main_cmdliner.exe cmd4 -n 3.14
   3.14
+
+  $ ./main_cmdliner.exe cmd5 --help=plain
+  NAME
+         ./main_cmdliner.exe-cmd5 - Hello positional
+  
+  SYNOPSIS
+         ./main_cmdliner.exe cmd5 [OPTION]… A B [C]
+  
+  COMMON OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         ./main_cmdliner.exe cmd5 exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         ./main_cmdliner.exe(1)
+  
+
+  $ ./main_cmdliner.exe cmd5 1.2 3.4
+  ((a 1.2) (b 3.4) (c 3.14))
+
+  $ ./main_cmdliner.exe cmd5 1.2 3.4 5.6
+  ((a 1.2) (b 3.4) (c 5.6))

--- a/test/common/dune
+++ b/test/common/dune
@@ -14,6 +14,8 @@
   -open
   Commandlang)
  (libraries base commandlang stdio)
+ (instrumentation
+  (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess

--- a/test/common/test_command.ml
+++ b/test/common/test_command.ml
@@ -1,6 +1,6 @@
 let cmd =
   Command.make
-    ~doc:"Hello command"
+    ~summary:"Hello command"
     (let open Command.Std in
      let+ () = Arg.return () in
      print_endline "Hello Wold";
@@ -9,7 +9,7 @@ let cmd =
 
 let cmd2 =
   Command.make
-    ~doc:"Hello let%bind command"
+    ~summary:"Hello let%bind command"
     (let%map_open.Command verbose = Arg.flag [ "verbose"; "v" ] ~doc:"be more verbose" in
      print_endline (Printf.sprintf "verbose = %b" verbose);
      ())
@@ -17,7 +17,7 @@ let cmd2 =
 
 let cmd3 =
   Command.make
-    ~doc:"Hello cmd3"
+    ~summary:"Hello cmd3"
     (let open Command.Std in
      let+ verbose = Arg.flag [ "verbose"; "v" ] ~doc:"be more verbose"
      and+ result =
@@ -34,12 +34,24 @@ let cmd3 =
 
 let cmd4 =
   Command.make
-    ~doc:"Hello let%bind command"
-    (let%map_open.Command f = Arg.named_req [ "n" ] Param.float ~doc:"a float to print" in
+    ~summary:"Hello let%bind command"
+    (let%map_open.Command f = Arg.named [ "n" ] Param.float ~doc:"a float to print" in
      print_endline (Float.to_string f);
      ())
 ;;
 
+let cmd5 =
+  Command.make
+    ~summary:"Hello positional"
+    (let%map_open.Command a = Arg.pos 0 ~docv:"A" Param.float
+     and b = Arg.pos 1 ~docv:"B" Param.float
+     and c = Arg.pos_with_default 2 ~docv:"C" Param.float ~default:3.14 in
+     print_s [%sexp { a : float; b : float; c : float }];
+     ())
+;;
+
 let cmd =
-  Command.group ~doc:"Hello" [ "cmd1", cmd; "cmd2", cmd2; "cmd3", cmd3; "cmd4", cmd4 ]
+  Command.group
+    ~summary:"Hello"
+    [ "cmd1", cmd; "cmd2", cmd2; "cmd3", cmd3; "cmd4", cmd4; "cmd5", cmd5 ]
 ;;


### PR DESCRIPTION
### Added

- Basic support for positional arguments.
- Enabled instrumentation.
- Adopted OCaml Code of Conduct.
- Added a FAQ page.
- Added test libraries.

### Changed

- Update tutorial to include positional arguments.

### Fixed

- Translation to `core.command` requires `(unit -> _) Command.t`

