### PR TITLE
New helpers & assorted changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
-## Unreleased
+## 0.0.1~preview-0.1 (2024-08-19)
 
 ### Added
 
+- Added basic support for `readme`.
+- Added `Arg.named_multi`.
+- Added param helpers: `stringable`,`validated strings`, `comma_separated`.
 - Basic support for positional arguments.
 - Enabled instrumentation.
 - Adopted OCaml Code of Conduct.
@@ -10,10 +13,10 @@
 
 ### Changed
 
+- Internal changes to AST to make it more consistent.
+- Improve generation of man pages when using `cmdliner` as target.
 - Update tutorial to include positional arguments.
 
 ### Fixed
 
 - Translation to `core.command` requires `(unit -> _) Command.t`
-
-### Removed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 Declarative Command-line Parsing for OCaml.
 
+## Synopsys
+
+Commandlang is a library for creating command-line parsers in OCaml. Implemented as an OCaml EDSL, its declarative specification language lives at the intersection of other well-established similar libraries.
+
+Commandlang doesn't include an execution engine. Instead, Commandlang parsers are automatically translated to `cmdliner`, `core.command`, or `climate` commands for execution.
+
+Our goal is to provide an approachable, flexible, and user-friendly interface while allowing users to choose the backend runtime that best suits their needs.
+
 ## Documentation
 
 Commandlang's documentation is published [here](https://mbarbin.github.io/commandlang).
@@ -38,10 +46,6 @@ The `commandlang` developers are enthusiastic to the prospect of compatible ways
 As developers of CLI tools written in OCaml, we aim to avoid a strong commitment to any single library if possible, especially concerning the runtime aspects. This is particularly relevant for new commands written today.
 
 In this spirit, we created `commandlang`, a new library that offers a unique twist: it doesn't implement its own runtime. Instead, it translates its parsers into `cmdliner`, `core.command`, or `climate` parsers, making it compatible with all their execution engines.
-
-# Motivation
-
-Our goal is to provide an approachable, flexible, and user-friendly interface while allowing users to choose the backend runtime that best suits their needs.
 
 Our current preferred target is depicted below, but other combinations are possible:
 

--- a/doc/docs/explanation/future_plans.md
+++ b/doc/docs/explanation/future_plans.md
@@ -22,10 +22,10 @@ Another area of focus is the generation of complex man pages. `cmdliner` has exc
 The rendering to simple strings could be exported by a standalone `cmdliner` helper library to reduce dependencies. We could then reuse and integrate this in the translation to `core.command` and `climate`. This part is more prospective and may require some coordination with the developers of other libraries.
 
 ### Tasks
-- [ ] Add support for one-line summaries of help messages
+- [x] Add support for one-line summaries and readme help pages.
 - [ ] Design optional information for specification language based on `cmdliner`
-- [ ] Create a standalone `cmdliner` helper library for rendering to simple strings
-- [ ] Integrate `cmdliner` design into `core.command` and `climate`
+- [ ] Create a standalone helper library for rendering to simple strings
+- [ ] Integrate design into translation to `core.command` and `climate`
 
 ## Auto-Completion
 

--- a/doc/docs/tutorials/getting-started/README.md
+++ b/doc/docs/tutorials/getting-started/README.md
@@ -220,9 +220,13 @@ let cmd =
     ~summary:"A simple calculator"
     (let open Command.Std in
      let+ op =
-       Arg.named [ "op" ] (Param.enumerated (module Operator)) ~doc:"operation to perform"
-     and+ a = Arg.pos 0 ~docv:"a" Param.float ~doc:"first operand"
-     and+ b = Arg.pos 1 ~docv:"b" Param.float ~doc:"second operand"
+       Arg.named
+         [ "op" ]
+         (Param.enumerated (module Operator))
+         ~docv:"OP"
+         ~doc:"operation to perform"
+     and+ a = Arg.pos ~pos:0 Param.float ~docv:"a" ~doc:"first operand"
+     and+ b = Arg.pos ~pos:1 Param.float ~docv:"b" ~doc:"second operand"
      and+ verbose = Arg.flag [ "verbose" ] ~doc:"print debug information" in
      if verbose then Printf.printf "op: %s, a: %f, b: %f\n" (Operator.to_string op) a b;
      print_endline (Operator.eval op a b |> string_of_float))
@@ -252,21 +256,21 @@ NAME
        my-calculator - A simple calculator
 
 SYNOPSIS
-       my-calculator [--op=VAL] [--verbose] [OPTION]… a b
+       my-calculator [--op=OP] [--verbose] [OPTION]… a b
 
 ARGUMENTS
        a (required)
-           first operand
+           first operand.
 
        b (required)
-           second operand
+           second operand.
 
 OPTIONS
-       --op=VAL (required)
-           operation to perform
+       --op=OP (required)
+           operation to perform. OP must be either 'add' or 'mul'.
 
        --verbose
-           print debug information
+           print debug information.
 
 COMMON OPTIONS
        --help[=FMT] (default=auto)
@@ -297,7 +301,7 @@ Additionally, we don't need to worry about handling invalid usages, this is done
 $ ./my-calculator --op=not-found 1 2.5
 my-calculator: option '--op': invalid value 'not-found', expected either
                'add' or 'mul'
-Usage: my-calculator [--op=VAL] [--verbose] [OPTION]… a b
+Usage: my-calculator [--op=OP] [--verbose] [OPTION]… a b
 Try 'my-calculator --help' for more information.
 [124]
 ```
@@ -306,7 +310,7 @@ Try 'my-calculator --help' for more information.
 $ ./my-calculator --op=add true 2.5
 my-calculator: a argument: invalid value 'true', expected a floating point
                number
-Usage: my-calculator [--op=VAL] [--verbose] [OPTION]… a b
+Usage: my-calculator [--op=OP] [--verbose] [OPTION]… a b
 Try 'my-calculator --help' for more information.
 [124]
 ```

--- a/doc/docs/tutorials/getting-started/lib/getting_started.ml
+++ b/doc/docs/tutorials/getting-started/lib/getting_started.ml
@@ -37,9 +37,13 @@ let cmd =
     ~summary:"A simple calculator"
     (let open Command.Std in
      let+ op =
-       Arg.named [ "op" ] (Param.enumerated (module Operator)) ~doc:"operation to perform"
-     and+ a = Arg.pos 0 ~docv:"a" Param.float ~doc:"first operand"
-     and+ b = Arg.pos 1 ~docv:"b" Param.float ~doc:"second operand"
+       Arg.named
+         [ "op" ]
+         (Param.enumerated (module Operator))
+         ~docv:"OP"
+         ~doc:"operation to perform"
+     and+ a = Arg.pos ~pos:0 Param.float ~docv:"a" ~doc:"first operand"
+     and+ b = Arg.pos ~pos:1 Param.float ~docv:"b" ~doc:"second operand"
      and+ verbose = Arg.flag [ "verbose" ] ~doc:"print debug information" in
      if verbose then Printf.printf "op: %s, a: %f, b: %f\n" (Operator.to_string op) a b;
      print_endline (Operator.eval op a b |> string_of_float))

--- a/lib/commandlang_ast/src/ast.ml
+++ b/lib/commandlang_ast/src/ast.ml
@@ -8,7 +8,7 @@ end
 module Param = struct
   type 'a t =
     | Conv :
-        { docv : string
+        { docv : string option
         ; parse : 'a parse
         ; print : 'a print
         }
@@ -23,6 +23,7 @@ module Param = struct
         ; choices : (string * 'a) Nonempty_list.t
         }
         -> 'a t
+    | Comma_separated : 'a t -> 'a list t
 end
 
 module Arg = struct
@@ -46,52 +47,59 @@ module Arg = struct
         -> bool t
     | Named :
         { names : string Nonempty_list.t
-        ; doc : string
-        ; docv : string option
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
+    | Named_multi :
+        { names : string Nonempty_list.t
+        ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
+        }
+        -> 'a list t
     | Named_opt :
         { names : string Nonempty_list.t
-        ; doc : string
-        ; docv : string option
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a option t
     | Named_with_default :
         { names : string Nonempty_list.t
-        ; doc : string
-        ; docv : string option
         ; param : 'a Param.t
         ; default : 'a
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
     | Pos :
-        { doc : string option
-        ; docv : string option
-        ; index : int
+        { pos : int
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
     | Pos_opt :
-        { doc : string option
-        ; docv : string option
-        ; index : int
+        { pos : int
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a option t
     | Pos_with_default :
-        { doc : string option
-        ; docv : string option
-        ; index : int
+        { pos : int
         ; param : 'a Param.t
         ; default : 'a
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
     | Pos_all :
-        { doc : string option
+        { param : 'a Param.t
         ; docv : string option
-        ; param : 'a Param.t
+        ; doc : string
         }
         -> 'a list t
 end
@@ -101,11 +109,13 @@ module Command = struct
     | Make :
         { arg : 'a Arg.t
         ; summary : string
+        ; readme : (unit -> string) option
         }
         -> 'a t
     | Group :
         { default : 'a Arg.t option
         ; summary : string
+        ; readme : (unit -> string) option
         ; subcommands : (string * 'a t) list
         }
         -> 'a t

--- a/lib/commandlang_ast/src/ast.mli
+++ b/lib/commandlang_ast/src/ast.mli
@@ -8,7 +8,7 @@ end
 module Param : sig
   type 'a t =
     | Conv :
-        { docv : string
+        { docv : string option
         ; parse : 'a parse
         ; print : 'a print
         }
@@ -23,6 +23,7 @@ module Param : sig
         ; choices : (string * 'a) Nonempty_list.t
         }
         -> 'a t
+    | Comma_separated : 'a t -> 'a list t
 end
 
 module Arg : sig
@@ -46,52 +47,59 @@ module Arg : sig
         -> bool t
     | Named :
         { names : string Nonempty_list.t
-        ; doc : string
-        ; docv : string option
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
+    | Named_multi :
+        { names : string Nonempty_list.t
+        ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
+        }
+        -> 'a list t
     | Named_opt :
         { names : string Nonempty_list.t
-        ; doc : string
-        ; docv : string option
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a option t
     | Named_with_default :
         { names : string Nonempty_list.t
-        ; doc : string
-        ; docv : string option
         ; param : 'a Param.t
         ; default : 'a
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
     | Pos :
-        { doc : string option
-        ; docv : string option
-        ; index : int
+        { pos : int
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
     | Pos_opt :
-        { doc : string option
-        ; docv : string option
-        ; index : int
+        { pos : int
         ; param : 'a Param.t
+        ; docv : string option
+        ; doc : string
         }
         -> 'a option t
     | Pos_with_default :
-        { doc : string option
-        ; docv : string option
-        ; index : int
+        { pos : int
         ; param : 'a Param.t
         ; default : 'a
+        ; docv : string option
+        ; doc : string
         }
         -> 'a t
     | Pos_all :
-        { doc : string option
+        { param : 'a Param.t
         ; docv : string option
-        ; param : 'a Param.t
+        ; doc : string
         }
         -> 'a list t
 end
@@ -101,11 +109,13 @@ module Command : sig
     | Make :
         { arg : 'a Arg.t
         ; summary : string
+        ; readme : (unit -> string) option
         }
         -> 'a t
     | Group :
         { default : 'a Arg.t option
         ; summary : string
+        ; readme : (unit -> string) option
         ; subcommands : (string * 'a t) list
         }
         -> 'a t

--- a/lib/commandlang_to_base/src/translate.ml
+++ b/lib/commandlang_to_base/src/translate.ml
@@ -6,7 +6,7 @@ module Config = struct
     }
 
   let create
-    ?(auto_add_short_aliases = true)
+    ?(auto_add_short_aliases = false)
     ?(auto_add_one_dash_aliases = false)
     ?(full_flags_required = true)
     ()
@@ -22,7 +22,7 @@ end
 module Param = struct
   type 'a t = { arg_type : 'a Command.Arg_type.t }
 
-  let project : type a. a Ast.Param.t -> a t = function
+  let rec project : type a. a Ast.Param.t -> a t = function
     | Conv { docv = _; parse; print = _ } ->
       let parse s =
         match parse s with
@@ -41,43 +41,45 @@ module Param = struct
             ~list_values_in_help:(Option.is_none docv)
             (hd :: tl)
       }
+    | Comma_separated t ->
+      { arg_type = Command.Arg_type.comma_separated (t |> project).arg_type }
   ;;
 end
-
-let project_flag_names (hd :: tl : _ Nonempty_list.t) ~(config : Config.t) =
-  let map_flag name = if String.length name = 1 then name else "--" ^ name in
-  let present = Set.of_list (module String) (hd :: tl) in
-  let tl =
-    List.concat
-      [ (if String.length hd > 1 && config.auto_add_short_aliases
-         then (
-           let short_alias = String.sub hd ~pos:0 ~len:1 in
-           if Set.mem present short_alias then [] else [ short_alias ])
-         else [])
-      ; (if String.length hd > 1 && config.auto_add_one_dash_aliases then [ hd ] else [])
-      ; List.map tl ~f:map_flag
-      ]
-  in
-  Nonempty_list.(map_flag hd :: tl)
-;;
 
 module Arg = struct
   type 'a t = { param : 'a Command.Param.t }
 
-  let check_positional_index ~positional_index ~index =
-    let expected = !positional_index + 1 in
-    if index = expected
-    then positional_index := index
+  let project_flag_names (hd :: tl : _ Nonempty_list.t) ~(config : Config.t) =
+    let map_flag name = if String.length name = 1 then name else "--" ^ name in
+    let present = Set.of_list (module String) (hd :: tl) in
+    let tl =
+      List.concat
+        [ (if String.length hd > 1 && config.auto_add_short_aliases
+           then (
+             let short_alias = String.sub hd ~pos:0 ~len:1 in
+             if Set.mem present short_alias then [] else [ short_alias ])
+           else [])
+        ; (if String.length hd > 1 && config.auto_add_one_dash_aliases then [ hd ] else [])
+        ; List.map tl ~f:map_flag
+        ]
+    in
+    Nonempty_list.(map_flag hd :: tl)
+  ;;
+
+  let check_positional_index ~last_positional_index ~next_positional_index =
+    let expected = !last_positional_index + 1 in
+    if next_positional_index = expected
+    then last_positional_index := next_positional_index
     else
       Error.raise_s
         [%sexp
           "Positional arguments must be supplied in consecutive order"
-          , { expected : int; got = (index : int) }]
+          , { expected : int; got = (next_positional_index : int) }]
   ;;
 
   let project : type a. a Ast.Arg.t -> config:Config.t -> a t =
     fun ast ~(config : Config.t) ->
-    let positional_index = ref (-1) in
+    let last_positional_index = ref (-1) in
     let rec project : type a. a Ast.Arg.t -> a t = function
       | Return x -> { param = Command.Param.return x }
       | Map { x; f } ->
@@ -95,35 +97,7 @@ module Arg = struct
         let (name :: aliases) = project_flag_names names ~config in
         let flag = Command.Flag.no_arg in
         { param = Command.Param.flag ~aliases name flag ~doc }
-      | Named_opt { names; doc; docv; param } ->
-        let (name :: aliases) = project_flag_names names ~config in
-        let { Param.arg_type } = param |> Param.project in
-        { param =
-            Command.Param.flag
-              ~aliases
-              ?full_flag_required:(Option.some_if config.full_flags_required ())
-              name
-              (Command.Flag.optional arg_type)
-              ~doc:
-                (match docv with
-                 | None -> doc
-                 | Some docv -> docv ^ " " ^ doc)
-        }
-      | Named_with_default { names; doc; docv; param; default } ->
-        let (name :: aliases) = project_flag_names names ~config in
-        let { Param.arg_type } = param |> Param.project in
-        { param =
-            Command.Param.flag
-              ~aliases
-              ?full_flag_required:(Option.some_if config.full_flags_required ())
-              name
-              (Command.Flag.optional_with_default default arg_type)
-              ~doc:
-                (match docv with
-                 | None -> doc
-                 | Some docv -> docv ^ " " ^ doc)
-        }
-      | Named { names; doc; docv; param } ->
+      | Named { names; param; docv; doc } ->
         let (name :: aliases) = project_flag_names names ~config in
         let { Param.arg_type } = param |> Param.project in
         { param =
@@ -137,22 +111,64 @@ module Arg = struct
                  | None -> doc
                  | Some docv -> docv ^ " " ^ doc)
         }
-      | Pos { doc = _; docv; index; param } ->
-        check_positional_index ~positional_index ~index;
+      | Named_multi { names; param; docv; doc } ->
+        let (name :: aliases) = project_flag_names names ~config in
+        let { Param.arg_type } = param |> Param.project in
+        { param =
+            Command.Param.flag
+              ~aliases
+              ?full_flag_required:(Option.some_if config.full_flags_required ())
+              name
+              (Command.Flag.listed arg_type)
+              ~doc:
+                (match docv with
+                 | None -> doc
+                 | Some docv -> docv ^ " " ^ doc)
+        }
+      | Named_opt { names; param; docv; doc } ->
+        let (name :: aliases) = project_flag_names names ~config in
+        let { Param.arg_type } = param |> Param.project in
+        { param =
+            Command.Param.flag
+              ~aliases
+              ?full_flag_required:(Option.some_if config.full_flags_required ())
+              name
+              (Command.Flag.optional arg_type)
+              ~doc:
+                (match docv with
+                 | None -> doc
+                 | Some docv -> docv ^ " " ^ doc)
+        }
+      | Named_with_default { names; param; default; docv; doc } ->
+        let (name :: aliases) = project_flag_names names ~config in
+        let { Param.arg_type } = param |> Param.project in
+        { param =
+            Command.Param.flag
+              ~aliases
+              ?full_flag_required:(Option.some_if config.full_flags_required ())
+              name
+              (Command.Flag.optional_with_default default arg_type)
+              ~doc:
+                (match docv with
+                 | None -> doc
+                 | Some docv -> docv ^ " " ^ doc)
+        }
+      | Pos { pos; param; docv; doc = _ } ->
+        check_positional_index ~last_positional_index ~next_positional_index:pos;
         let { Param.arg_type } = param |> Param.project in
         let anon = Command.Anons.(Option.value docv ~default:"VAL" %: arg_type) in
         { param = Command.Param.anon anon }
-      | Pos_opt { doc = _; docv; index; param } ->
-        check_positional_index ~positional_index ~index;
+      | Pos_opt { pos; param; docv; doc = _ } ->
+        check_positional_index ~last_positional_index ~next_positional_index:pos;
         let { Param.arg_type } = param |> Param.project in
         let anon = Command.Anons.(Option.value docv ~default:"VAL" %: arg_type) in
         { param = Command.Param.anon (Command.Anons.maybe anon) }
-      | Pos_with_default { doc = _; docv; index; param; default } ->
-        check_positional_index ~positional_index ~index;
+      | Pos_with_default { pos; param; default; docv; doc = _ } ->
+        check_positional_index ~last_positional_index ~next_positional_index:pos;
         let { Param.arg_type } = param |> Param.project in
         let anon = Command.Anons.(Option.value docv ~default:"VAL" %: arg_type) in
         { param = Command.Param.anon (Command.Anons.maybe_with_default default anon) }
-      | Pos_all { doc = _; docv; param } ->
+      | Pos_all { param; docv; doc = _ } ->
         let { Param.arg_type } = param |> Param.project in
         let anon = Command.Anons.(Option.value docv ~default:"VAL" %: arg_type) in
         { param = Command.Param.anon (Command.Anons.sequence anon) }
@@ -171,16 +187,17 @@ module Command = struct
     let rec unit : unit Ast.Command.t -> Command.t =
       fun command ->
       match command with
-      | Make { arg; summary } ->
+      | Make { arg; summary; readme } ->
         let { Arg.param } = arg |> Arg.project ~config in
         Command.basic
           ~summary
-          ?readme:None
+          ?readme
           (let%map_open.Command () = param in
            fun () -> ())
-      | Group { default = _; summary; subcommands } ->
+      | Group { default = _; readme; summary; subcommands } ->
         Command.group
           ~summary
+          ?readme
           (List.map subcommands ~f:(fun (name, arg) -> name, arg |> unit))
     in
     unit command
@@ -195,12 +212,13 @@ module Command = struct
     let rec basic : (unit -> unit) Ast.Command.t -> Command.t =
       fun command ->
       match command with
-      | Make { arg; summary } ->
+      | Make { arg; summary; readme } ->
         let { Arg.param } = arg |> Arg.project ~config in
-        Command.basic ~summary ?readme:None param
-      | Group { default = _; summary; subcommands } ->
+        Command.basic ~summary ?readme param
+      | Group { default = _; summary; readme; subcommands } ->
         Command.group
           ~summary
+          ?readme
           (List.map subcommands ~f:(fun (name, arg) -> name, arg |> basic))
     in
     basic command
@@ -215,12 +233,13 @@ module Command = struct
     let rec or_error : (unit -> unit Or_error.t) Ast.Command.t -> Command.t =
       fun command ->
       match command with
-      | Make { arg; summary } ->
+      | Make { arg; summary; readme } ->
         let { Arg.param } = arg |> Arg.project ~config in
-        Command.basic_or_error ~summary ?readme:None param
-      | Group { default = _; summary; subcommands } ->
+        Command.basic_or_error ~summary ?readme param
+      | Group { default = _; summary; readme; subcommands } ->
         Command.group
           ~summary
+          ?readme
           (List.map subcommands ~f:(fun (name, arg) -> name, arg |> or_error))
     in
     or_error command
@@ -234,3 +253,7 @@ let _arg a = a |> To_ast.arg |> Arg.project
 let unit ?config a = a |> To_ast.command |> Command.unit ?config
 let basic ?config a = a |> To_ast.command |> Command.basic ?config
 let or_error ?config a = a |> To_ast.command |> Command.or_error ?config
+
+module Private = struct
+  module Arg = Arg
+end

--- a/lib/commandlang_to_base/src/translate.mli
+++ b/lib/commandlang_to_base/src/translate.mli
@@ -2,7 +2,7 @@ module Config : sig
   type t
 
   val create
-    :  ?auto_add_short_aliases:bool (** default to [true]. *)
+    :  ?auto_add_short_aliases:bool (** default to [false]. *)
     -> ?auto_add_one_dash_aliases:bool
          (** default to [false]. We recommend enabling one dash aliases to be
              used for migration path only. *)
@@ -25,3 +25,14 @@ val or_error
     is probably not quite right, due to the body of the command being evaluated
     as an argument. *)
 val unit : ?config:Config.t -> unit Commandlang.Command.t -> Command.t
+
+module Private : sig
+  (** This module is exported for testing purposes only. Its signature may
+      change in breaking ways without any notice. Do not use. *)
+
+  module Arg : sig
+    type 'a t = { param : 'a Command.Param.t }
+
+    val project : 'a Commandlang_ast.Ast.Arg.t -> config:Config.t -> 'a t
+  end
+end

--- a/lib/commandlang_to_cmdliner/src/translate.ml
+++ b/lib/commandlang_to_cmdliner/src/translate.ml
@@ -1,81 +1,192 @@
 module Param = struct
-  let project : type a. a Ast.Param.t -> a Cmdliner.Arg.conv = function
-    | Conv { docv; parse; print } -> Cmdliner.Arg.conv ~docv (parse, print)
+  let rec project : type a. a Ast.Param.t -> a Cmdliner.Arg.conv = function
+    | Conv { docv; parse; print } -> Cmdliner.Arg.conv ?docv (parse, print)
     | String -> Cmdliner.Arg.string
     | Int -> Cmdliner.Arg.int
     | Float -> Cmdliner.Arg.float
     | Bool -> Cmdliner.Arg.bool
     | File -> Cmdliner.Arg.file
     | Enum { docv = _; choices = hd :: tl } -> Cmdliner.Arg.enum (hd :: tl)
+    | Comma_separated param -> Cmdliner.Arg.list ~sep:',' (project param)
+  ;;
+
+  let rec docv : type a. a Ast.Param.t -> string option = function
+    | Conv { docv; parse = _; print = _ } -> docv
+    | String -> Some "STRING"
+    | Int -> Some "INT"
+    | Float -> Some "FLOAT"
+    | Bool -> Some "BOOL"
+    | File -> Some "FILE"
+    | Enum { docv; choices = _ } -> docv
+    | Comma_separated param ->
+      docv param |> Option.map (fun docv -> Printf.sprintf "[%s,..]" docv)
   ;;
 end
 
 module Arg = struct
+  let docv_of_param ~docv ~param =
+    match docv with
+    | Some _ -> docv
+    | None -> Param.docv param
+  ;;
+
+  let with_dot_suffix ~doc =
+    let needs_dot =
+      let trim = String.trim doc in
+      String.length trim > 0 && trim.[String.length trim - 1] <> '.'
+    in
+    if needs_dot then doc ^ "." else doc
+  ;;
+
+  let rec doc_of_param : type a. doc:string -> param:a Ast.Param.t -> string =
+    fun ~doc ~param ->
+    match (param : _ Ast.Param.t) with
+    | Conv _ | String | Int | Float | Bool | File -> with_dot_suffix ~doc
+    | Enum { docv = _; choices = hd :: tl } ->
+      Printf.sprintf
+        "%s. $(docv) must be %s."
+        doc
+        (Cmdliner.Arg.doc_alts_enum ~quoted:true (hd :: tl))
+    | Comma_separated param -> doc_of_param ~doc:(doc ^ " (comma-separated)") ~param
+  ;;
+
   let rec project : type a. a Ast.Arg.t -> a Cmdliner.Term.t = function
     | Return x -> Cmdliner.Term.const x
     | Map { x; f } -> Cmdliner.Term.map f (project x)
     | Both (a, b) -> Cmdliner.Term.product (project a) (project b)
     | Apply { f; x } -> Cmdliner.Term.app (project f) (project x)
     | Flag { names = hd :: tl; doc } ->
+      let doc = with_dot_suffix ~doc in
       Cmdliner.Arg.value (Cmdliner.Arg.flag (Cmdliner.Arg.info ~doc (hd :: tl)))
-    | Named { names = hd :: tl; doc; docv; param } ->
+    | Named { names = hd :: tl; param; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.required
         (Cmdliner.Arg.opt
            (Cmdliner.Arg.some (Param.project param))
            None
            (Cmdliner.Arg.info ?docv ~doc (hd :: tl)))
-    | Named_opt { names = hd :: tl; doc; docv; param } ->
+    | Named_multi { names = hd :: tl; param; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
+      Cmdliner.Arg.value
+        (Cmdliner.Arg.opt_all
+           (Param.project param)
+           []
+           (Cmdliner.Arg.info ?docv ~doc (hd :: tl)))
+    | Named_opt { names = hd :: tl; param; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.value
         (Cmdliner.Arg.opt
            (Cmdliner.Arg.some (Param.project param))
            None
            (Cmdliner.Arg.info ?docv ~doc (hd :: tl)))
-    | Named_with_default { names = hd :: tl; doc; docv; param; default } ->
+    | Named_with_default { names = hd :: tl; param; default; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.value
         (Cmdliner.Arg.opt
            (Param.project param)
            default
            (Cmdliner.Arg.info ?docv ~doc (hd :: tl)))
-    | Pos { doc; docv; index; param } ->
+    | Pos { pos; param; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.required
         (Cmdliner.Arg.pos
-           index
+           pos
            (Cmdliner.Arg.some (Param.project param))
            None
-           (Cmdliner.Arg.info ?docv ?doc []))
-    | Pos_opt { doc; docv; index; param } ->
+           (Cmdliner.Arg.info ?docv ~doc []))
+    | Pos_opt { pos; param; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.value
         (Cmdliner.Arg.pos
-           index
+           pos
            (Cmdliner.Arg.some (Param.project param))
            None
-           (Cmdliner.Arg.info ?docv ?doc []))
-    | Pos_with_default { doc; docv; index; param; default } ->
+           (Cmdliner.Arg.info ?docv ~doc []))
+    | Pos_with_default { pos; param; default; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.value
         (Cmdliner.Arg.pos
-           index
+           pos
            (Param.project param)
            default
-           (Cmdliner.Arg.info ?docv ?doc []))
-    | Pos_all { doc; docv; param } ->
+           (Cmdliner.Arg.info ?docv ~doc []))
+    | Pos_all { param; docv; doc } ->
+      let doc = doc_of_param ~doc ~param in
+      let docv = docv_of_param ~docv ~param in
       Cmdliner.Arg.value
-        (Cmdliner.Arg.pos_all (Param.project param) [] (Cmdliner.Arg.info ?docv ?doc []))
+        (Cmdliner.Arg.pos_all (Param.project param) [] (Cmdliner.Arg.info ?docv ~doc []))
   ;;
 end
 
 module Command = struct
+  type block = [ `P of string ]
+
+  let manpage_of_readme ~readme : block list =
+    let readme = readme () in
+    let lines = String.split_on_char '\n' readme in
+    let paragraphs = Queue.create () in
+    let buffer = Buffer.create 256 in
+    let flush_line () =
+      let line = Buffer.contents buffer in
+      if not (String.length line = 0)
+      then (
+        Queue.push (`P line) paragraphs;
+        Buffer.clear buffer)
+    in
+    let add_separator () = if Buffer.length buffer > 0 then Buffer.add_char buffer ' ' in
+    let rec loop lines =
+      match lines with
+      | [] -> flush_line ()
+      | "" :: lines ->
+        flush_line ();
+        Queue.push (`P "\n") paragraphs;
+        loop lines
+      | line :: lines ->
+        add_separator ();
+        Buffer.add_string buffer line;
+        loop lines
+    in
+    loop lines;
+    Queue.fold (fun tl hd -> hd :: tl) [] paragraphs |> List.rev
+  ;;
+
   let rec project
     : type a. ?version:string -> a Ast.Command.t -> name:string -> a Cmdliner.Cmd.t
     =
     fun ?version command ~name ->
     match (command : _ Ast.Command.t) with
-    | Make { arg; summary } ->
-      let info = Cmdliner.Cmd.info ~doc:summary ?version name in
+    | Make { arg; summary; readme } ->
+      let info =
+        Cmdliner.Cmd.info
+          ?man:
+            (readme
+             |> Option.map (fun readme ->
+               (manpage_of_readme ~readme :> Cmdliner.Manpage.block list)))
+          ~doc:summary
+          ?version
+          name
+      in
       Cmdliner.Cmd.v info (Arg.project arg)
-    | Group { default; summary; subcommands } ->
-      let cmds = subcommands |> List.map (fun (name, arg) -> project arg ~name) in
-      let info = Cmdliner.Cmd.info ~doc:summary ?version name in
-      Cmdliner.Cmd.group ?default:(default |> Option.map Arg.project) info cmds
+    | Group { default; summary; readme; subcommands } ->
+      let commands = subcommands |> List.map (fun (name, arg) -> project arg ~name) in
+      let info =
+        Cmdliner.Cmd.info
+          ?man:
+            (readme
+             |> Option.map (fun readme ->
+               (manpage_of_readme ~readme :> Cmdliner.Manpage.block list)))
+          ~doc:summary
+          ?version
+          name
+      in
+      Cmdliner.Cmd.group ?default:(default |> Option.map Arg.project) info commands
   ;;
 end
 
@@ -84,3 +195,8 @@ module To_ast = Commandlang.Command.Private.To_ast
 let _param p = p |> To_ast.param |> Param.project
 let _arg a = a |> To_ast.arg |> Arg.project
 let command ?version a ~name = a |> To_ast.command |> Command.project ?version ~name
+
+module Private = struct
+  module Arg = Arg
+  module Command = Command
+end

--- a/lib/commandlang_to_cmdliner/src/translate.mli
+++ b/lib/commandlang_to_cmdliner/src/translate.mli
@@ -3,3 +3,17 @@ val command
   -> 'a Commandlang.Command.t
   -> name:string
   -> 'a Cmdliner.Cmd.t
+
+module Private : sig
+  (** This module is exported for testing purposes only. Its signature may
+      change in breaking ways without any notice. Do not use. *)
+
+  module Arg : sig
+    val with_dot_suffix : doc:string -> string
+    val doc_of_param : doc:string -> param:'a Ast.Param.t -> string
+  end
+
+  module Command : sig
+    val manpage_of_readme : readme:(unit -> string) -> [ `P of string ] list
+  end
+end

--- a/lib/commandlang_to_cmdliner/test/dune
+++ b/lib/commandlang_to_cmdliner/test/dune
@@ -2,8 +2,20 @@
  (name commandlang_to_cmdliner_test)
  (public_name commandlang-test.commandlang_to_cmdliner_test)
  (inline_tests)
- (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries commandlang_to_cmdliner)
+ (flags
+  :standard
+  -w
+  +a-4-40-41-42-44-45-48-66
+  -warn-error
+  +a
+  -open
+  Base
+  -open
+  Expect_test_helpers_base)
+ (libraries
+  base
+  commandlang_to_cmdliner
+  expect_test_helpers_core.expect_test_helpers_base)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/test/cmdliner/run.t
+++ b/test/cmdliner/run.t
@@ -13,10 +13,10 @@
          cmd2 [--verbose] [OPTION]…
              Hello let%bind command
   
-         cmd3 [--bool=MYBOOL] [--int=VAL] [--verbose] [OPTION]…
+         cmd3 [--bool=MYBOOL] [--int=INT] [--verbose] [OPTION]…
              Hello cmd3
   
-         cmd4 [-n VAL] [OPTION]…
+         cmd4 [-n FLOAT] [OPTION]…
              Hello let%bind command
   
          cmd5 [OPTION]… A B [C]
@@ -84,7 +84,7 @@
   
   OPTIONS
          -v, --verbose
-             be more verbose
+             be more verbose.
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -129,18 +129,18 @@
          ./main_cmdliner.exe-cmd3 - Hello cmd3
   
   SYNOPSIS
-         ./main_cmdliner.exe cmd3 [--bool=MYBOOL] [--int=VAL] [--verbose]
+         ./main_cmdliner.exe cmd3 [--bool=MYBOOL] [--int=INT] [--verbose]
          [OPTION]…
   
   OPTIONS
          -b MYBOOL, --bool=MYBOOL
-             Specify a value
+             Specify a value.
   
-         -i VAL, --int=VAL (absent=42)
-             Specify an int
+         -i INT, --int=INT (absent=42)
+             Specify an int.
   
          -v, --verbose
-             be more verbose
+             be more verbose.
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -193,7 +193,7 @@
   $ ./main_cmdliner.exe cmd3 -vb=true
   ./main_cmdliner.exe: option '-b': invalid value '=true', either 'true' or
                        'false'
-  Usage: ./main_cmdliner.exe cmd3 [--bool=MYBOOL] [--int=VAL] [--verbose] [OPTION]…
+  Usage: ./main_cmdliner.exe cmd3 [--bool=MYBOOL] [--int=INT] [--verbose] [OPTION]…
   Try './main_cmdliner.exe cmd3 --help' or './main_cmdliner.exe --help' for more information.
   [124]
 
@@ -212,11 +212,11 @@
          ./main_cmdliner.exe-cmd4 - Hello let%bind command
   
   SYNOPSIS
-         ./main_cmdliner.exe cmd4 [-n VAL] [OPTION]…
+         ./main_cmdliner.exe cmd4 [-n FLOAT] [OPTION]…
   
   OPTIONS
-         -n VAL (required)
-             a float to print
+         -n FLOAT (required)
+             a float to print.
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -244,7 +244,7 @@
 
   $ ./main_cmdliner.exe cmd4
   ./main_cmdliner.exe: required option -n is missing
-  Usage: ./main_cmdliner.exe cmd4 [-n VAL] [OPTION]…
+  Usage: ./main_cmdliner.exe cmd4 [-n FLOAT] [OPTION]…
   Try './main_cmdliner.exe cmd4 --help' or './main_cmdliner.exe --help' for more information.
   [124]
 
@@ -253,7 +253,7 @@
 
   $ ./main_cmdliner.exe cmd4 --n=3.14
   ./main_cmdliner.exe: unknown option '--n', did you mean '-n'?
-  Usage: ./main_cmdliner.exe cmd4 [-n VAL] [OPTION]…
+  Usage: ./main_cmdliner.exe cmd4 [-n FLOAT] [OPTION]…
   Try './main_cmdliner.exe cmd4 --help' or './main_cmdliner.exe --help' for more information.
   [124]
 
@@ -263,7 +263,7 @@
   $ ./main_cmdliner.exe cmd4 -n=3.14
   ./main_cmdliner.exe: option '-n': invalid value '=3.14', expected a floating
                        point number
-  Usage: ./main_cmdliner.exe cmd4 [-n VAL] [OPTION]…
+  Usage: ./main_cmdliner.exe cmd4 [-n FLOAT] [OPTION]…
   Try './main_cmdliner.exe cmd4 --help' or './main_cmdliner.exe --help' for more information.
   [124]
 
@@ -276,6 +276,16 @@
   
   SYNOPSIS
          ./main_cmdliner.exe cmd5 [OPTION]… A B [C]
+  
+  ARGUMENTS
+         A (required)
+             a first float.
+  
+         B (required)
+             a second float.
+  
+         C (absent=3.14)
+             another float.
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)

--- a/test/common/test_command.ml
+++ b/test/common/test_command.ml
@@ -43,9 +43,16 @@ let cmd4 =
 let cmd5 =
   Command.make
     ~summary:"Hello positional"
-    (let%map_open.Command a = Arg.pos 0 ~docv:"A" Param.float
-     and b = Arg.pos 1 ~docv:"B" Param.float
-     and c = Arg.pos_with_default 2 ~docv:"C" Param.float ~default:3.14 in
+    (let%map_open.Command a = Arg.pos ~pos:0 Param.float ~docv:"A" ~doc:"a first float"
+     and b = Arg.pos ~pos:1 Param.float ~docv:"B" ~doc:"a second float"
+     and c =
+       Arg.pos_with_default
+         ~pos:2
+         Param.float
+         ~default:3.14
+         ~docv:"C"
+         ~doc:"another float"
+     in
      print_s [%sexp { a : float; b : float; c : float }];
      ())
 ;;


### PR DESCRIPTION
## 0.0.1~preview-0.1 (2024-08-19)

### Added

- Added basic support for `readme`.
- Added `Arg.named_multi`.
- Added param helpers: `stringable`,`validated strings`, `comma_separated`.

### Changed

- Internal changes to AST to make it more consistent.
- Improve generation of man pages when using `cmdliner` as target.